### PR TITLE
Fix ListaCompartilhada DTO and add migration

### DIFF
--- a/ListaCompra/Controllers/ListaCompartilhadaController.cs
+++ b/ListaCompra/Controllers/ListaCompartilhadaController.cs
@@ -35,7 +35,7 @@ public class ListaCompartilhadaController : ControllerBase
 
 
     [HttpGet("{usuarioId}/{listaId}")]
-    public IActionResult RecuperaSessoesPorId(int usuarioId, int listaId)
+    public IActionResult RecuperaSessoesPorId(string usuarioId, int listaId)
     {
         ListaCompartilhadas listaCompartilhada = _contexto.ListaCompartilhada.FirstOrDefault(listaCompart => listaCompart.UsuarioId == usuarioId && listaCompart.ListaId == listaId);
         if (listaCompartilhada != null)

--- a/ListaCompra/Data/DTOs/ReadListacompartilhadaDto.cs
+++ b/ListaCompra/Data/DTOs/ReadListacompartilhadaDto.cs
@@ -2,7 +2,7 @@
 {
     public class ReadListaCompartilhadaDto
     {
-        public int UsuarioId { get; set; }
+        public string UsuarioId { get; set; }
         public int ListaId { get; set; }
     }
 }

--- a/ListaCompra/Migrations/20250604130148_TestMigration.Designer.cs
+++ b/ListaCompra/Migrations/20250604130148_TestMigration.Designer.cs
@@ -4,6 +4,7 @@ using ListaCompra.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ListaCompra.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250604130148_TestMigration")]
+    partial class TestMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ListaCompra/Migrations/20250604130148_TestMigration.cs
+++ b/ListaCompra/Migrations/20250604130148_TestMigration.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ListaCompra.Migrations
+{
+    /// <inheritdoc />
+    public partial class TestMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ListaCompartilhada",
+                columns: table => new
+                {
+                    UsuarioId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ListaId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ListaCompartilhada", x => new { x.UsuarioId, x.ListaId });
+                    table.ForeignKey(
+                        name: "FK_ListaCompartilhada_AspNetUsers_UsuarioId",
+                        column: x => x.UsuarioId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ListaCompartilhada_ListaDeCompras_ListaId",
+                        column: x => x.ListaId,
+                        principalTable: "ListaDeCompras",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ListaCompartilhada_ListaId",
+                table: "ListaCompartilhada",
+                column: "ListaId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ListaCompartilhada");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update `ReadListaCompartilhadaDto` to use string user id
- match controller `RecuperaSessoesPorId` signature
- generate `TestMigration` for `ListaCompartilhada`

## Testing
- `dotnet build ListaCompra/ListaCompra.csproj`
- `dotnet ef migrations add TestMigration`

------
https://chatgpt.com/codex/tasks/task_e_68404327b2e48328a87a086eebe620f8